### PR TITLE
dataclass: avoid the use of mutable default value

### DIFF
--- a/ansible_risk_insight/models.py
+++ b/ansible_risk_insight/models.py
@@ -204,7 +204,7 @@ class CallObject(JSONSerializable):
     type: str = ""
     key: str = ""
     called_from: str = ""
-    spec: Object = Object()
+    spec: Object = field(default_factory=Object)
 
     @classmethod
     def from_spec(cls, spec, caller):

--- a/ansible_risk_insight/scanner.py
+++ b/ansible_risk_insight/scanner.py
@@ -104,7 +104,7 @@ class ARIScanner(object):
 
     trees: list = field(default_factory=list)
     # for inventory object
-    additional: ObjectList = ObjectList()
+    additional: ObjectList = field(default_factory=ObjectList)
 
     taskcalls_in_trees: list = field(default_factory=list)
 


### PR DESCRIPTION
With the previous construction, two instances of the same class would share a
reference pointing on the same object.

This is likely to create unexpected behaviour and raise an error with
Python 3.11.

See: https://docs.python.org/3/library/dataclasses.html#mutable-default-values
