### PR TITLE
enable to specify custom rule dirs with `--rules-dir`

### DIFF
--- a/ansible_risk_insight/cli/__init__.py
+++ b/ansible_risk_insight/cli/__init__.py
@@ -49,6 +49,10 @@ class ARICLI:
         parser.add_argument("--show-all", action="store_true", help="if true, show findings even if missing dependencies are found")
         parser.add_argument("-o", "--output", help="if specified, show findings in json/yaml format", choices={"json", "yaml"})
         parser.add_argument("--out-dir", help="output directory for findings")
+        parser.add_argument(
+            "-r", "--rules-dir", help=f"specify custom rule directories. use `-R` instead to ignore default rules in {config.rules_dir}"
+        )
+        parser.add_argument("-R", "--rules-dir-without-default", help="specify custom rule directories and ignore default rules")
         args = parser.parse_args()
         self.args = args
 
@@ -84,6 +88,12 @@ class ARICLI:
             if role_meta:
                 role_name = role_meta.get("galaxy_info", {}).get("role_name", "")
 
+        rules_dir = ""
+        if args.rules_dir_without_default:
+            rules_dir = args.rules_dir_without_default
+        elif args.rules_dir:
+            rules_dir = args.rules_dir + ":" + config.rules_dir
+
         silent = False
         pretty = False
         if args.output:
@@ -101,6 +111,7 @@ class ARICLI:
 
         c = ARIScanner(
             root_dir=config.data_dir,
+            rules_dir=rules_dir,
             do_save=args.save,
             read_ram=read_ram,
             write_ram=write_ram,

--- a/ansible_risk_insight/risk_detector.py
+++ b/ansible_risk_insight/risk_detector.py
@@ -33,15 +33,17 @@ def key2name(key: str):
         return key.split(key_delimiter)[-1]
 
 
-def load_rules():
-    _rule_classes = load_classes_in_dir("rules", Rule, __file__)
+def load_rules(rules_dir: str = ""):
+    rules_dir_list = rules_dir.split(":")
     _rules = []
-    for r in _rule_classes:
-        try:
-            _rule = r()
-            _rules.append(_rule)
-        except Exception:
-            raise ValueError(f"failed to load a rule: {r}")
+    for _rules_dir in rules_dir_list:
+        _rule_classes = load_classes_in_dir(_rules_dir, Rule)
+        for r in _rule_classes:
+            try:
+                _rule = r()
+                _rules.append(_rule)
+            except Exception:
+                raise ValueError(f"failed to load a rule: {r}")
     _rules = sorted(_rules, key=lambda r: int(r.rule_id[-3:]))
     _rules = sorted(_rules, key=lambda r: r.precedence)
 
@@ -59,8 +61,8 @@ def make_subject_str(playbook_num: int, role_num: int):
     return subject
 
 
-def detect(contexts: List[AnsibleRunContext], collection_name: str = ""):
-    rules = load_rules()
+def detect(contexts: List[AnsibleRunContext], rules_dir: str = ""):
+    rules = load_rules(rules_dir)
 
     report_num = 1
 

--- a/ansible_risk_insight/tree.py
+++ b/ansible_risk_insight/tree.py
@@ -34,6 +34,7 @@ from .models import (
     LoadType,
     CallObject,
     TaskCall,
+    MutableContent,
     call_obj_from_spec,
 )
 from .finder import get_builtin_module_names
@@ -485,6 +486,7 @@ class TreeLoader(object):
             )
             if isinstance(call_obj, TaskCall):
                 taskcall = call_obj
+                taskcall.content = MutableContent.from_task_spec(taskcall.spec)
                 if len(child_objects.items) > 0:
                     c_obj = child_objects.items[0]
                     if taskcall.spec.executable_type == ExecutableType.MODULE_TYPE:

--- a/ansible_risk_insight/utils.py
+++ b/ansible_risk_insight/utils.py
@@ -500,7 +500,7 @@ def get_documentation_by_ansible_doc_command(fqcn: str, module_dir_path: str = "
     cmd_args = [f"ansible-doc {fqcn} --json {module_path_option}"]
     proc = subprocess.run(cmd_args, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
     if proc.stderr:
-        logging.error(f"error while getting the documentation for module `{fqcn}`: {proc.stderr}")
+        logging.debug(f"error while getting the documentation for module `{fqcn}`: {proc.stderr}")
         return ""
     wrapper_dict = json.loads(proc.stdout)
     doc_dict = wrapper_dict.get(fqcn, {}).get("doc", {})


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

- enable to specify custom rule dirs with `--rules-dir` or `-r`
  - support `-R` option too for ignoring default rules