### PR TITLE
rule result will be output by `--out-dir`

### DIFF
--- a/ansible_risk_insight/cli/__init__.py
+++ b/ansible_risk_insight/cli/__init__.py
@@ -47,8 +47,9 @@ class ARICLI:
         parser.add_argument("--without-ram", action="store_true", help="if true, RAM data is not used and not even updated")
         parser.add_argument("--update-ram", action="store_true", help="if true, RAM data is not used for scan but updated with the scan result")
         parser.add_argument("--show-all", action="store_true", help="if true, show findings even if missing dependencies are found")
-        parser.add_argument("-o", "--output", help="if specified, show findings in json/yaml format", choices={"json", "yaml"})
-        parser.add_argument("--out-dir", help="output directory for findings")
+        parser.add_argument("--json", help="if specified, show findings in json format")
+        parser.add_argument("--yaml", help="if specified, show findings in yaml format")
+        parser.add_argument("-o", "--out-dir", help="output directory for the rule evaluation result")
         parser.add_argument(
             "-r", "--rules-dir", help=f"specify custom rule directories. use `-R` instead to ignore default rules in {config.rules_dir}"
         )
@@ -96,9 +97,14 @@ class ARICLI:
 
         silent = False
         pretty = False
-        if args.output:
+        output_format = ""
+        if args.json or args.yaml:
             silent = True
             pretty = True
+            if args.json:
+                output_format = "json"
+            elif args.yaml:
+                output_format = "yaml"
 
         read_ram = True
         write_ram = True
@@ -118,7 +124,7 @@ class ARICLI:
             show_all=args.show_all,
             silent=silent,
             pretty=pretty,
-            output_format=args.output,
+            output_format=output_format,
         )
         if not silent and not pretty:
             print("Start preparing dependencies")

--- a/ansible_risk_insight/findings.py
+++ b/ansible_risk_insight/findings.py
@@ -48,7 +48,7 @@ class Findings:
         return json_str
 
     def save_rule_result(self, fpath=""):
-        json_str = jsonpickle.encode(self.report.get("ari_result", {}), make_refs=False)
+        json_str = jsonpickle.encode(self.report.get("ari_result", {}), make_refs=False, unpicklable=False)
         if fpath:
             with open(fpath, "w") as file:
                 file.write(json_str)

--- a/ansible_risk_insight/findings.py
+++ b/ansible_risk_insight/findings.py
@@ -47,6 +47,13 @@ class Findings:
                 file.write(json_str)
         return json_str
 
+    def save_rule_result(self, fpath=""):
+        json_str = jsonpickle.encode(self.report.get("ari_result", {}), make_refs=False)
+        if fpath:
+            with open(fpath, "w") as file:
+                file.write(json_str)
+        return json_str
+
     @staticmethod
     def load(fpath="", json_str=""):
         if fpath:

--- a/ansible_risk_insight/models.py
+++ b/ansible_risk_insight/models.py
@@ -805,6 +805,8 @@ class Annotation(JSONSerializable):
     key: str = ""
     value: any = None
 
+    rule_id: str = ""
+
     # TODO: avoid Annotation variants and remove `type`
     type: str = ""
 
@@ -1277,7 +1279,7 @@ class TaskCall(CallObject, RunTarget):
         matched = [an for an in self.annotations if hasattr(an, "type") and an.type == type_str and getattr(an, key, None) == val]
         return matched
 
-    def set_annotation(self, key: str, value: any):
+    def set_annotation(self, key: str, value: any, rule_id: str):
         end_to_set = False
         for an in self.annotations:
             if not hasattr(an, "key"):
@@ -1287,14 +1289,18 @@ class TaskCall(CallObject, RunTarget):
                 end_to_set = True
                 break
         if not end_to_set:
-            self.annotations.append(Annotation(key=key, value=value))
+            self.annotations.append(Annotation(key=key, value=value, rule_id=rule_id))
         return
 
-    def get_annotation(self, key: str, __default: any = None):
+    def get_annotation(self, key: str, __default: any = None, rule_id: str = ""):
         value = __default
         for an in self.annotations:
             if not hasattr(an, "key"):
                 continue
+            if rule_id:
+                if hasattr(an, "rule_id"):
+                    if an.rule_id != rule_id:
+                        continue
             if getattr(an, "key") == key:
                 value = getattr(an, "value", __default)
                 break

--- a/ansible_risk_insight/models.py
+++ b/ansible_risk_insight/models.py
@@ -1947,9 +1947,9 @@ class NodeResult(JSONSerializable):
 
 
 @dataclass
-class TreeResult(JSONSerializable):
-    tree_type: str = ""  # playbook or role
-    tree_name: str = ""
+class TargetResult(JSONSerializable):
+    target_type: str = ""  # playbook or role
+    target_name: str = ""
     nodes: List[NodeResult] = field(default_factory=list)
 
     def applied_rules(self):
@@ -2006,12 +2006,12 @@ class TreeResult(JSONSerializable):
 
     def _filter(self, type):
         filtered_nodes = [nr for nr in self.nodes if isinstance(nr.node, type)]
-        return TreeResult(tree_type=self.tree_type, tree_name=self.tree_name, nodes=filtered_nodes)
+        return TargetResult(target_type=self.target_type, target_name=self.target_name, nodes=filtered_nodes)
 
 
 @dataclass
 class ARIResult(JSONSerializable):
-    trees: List[TreeResult] = field(default_factory=list)
+    targets: List[TargetResult] = field(default_factory=list)
 
     def playbooks(self):
         return self._filter("playbook")
@@ -2034,11 +2034,11 @@ class ARIResult(JSONSerializable):
         return self._find_by_name(name)
 
     def _find_by_name(self, name):
-        filtered_trees = [tr for tr in self.trees if tr.tree_name == name]
-        if not filtered_trees:
+        filtered_targets = [tr for tr in self.targets if tr.target_name == name]
+        if not filtered_targets:
             return None
-        return filtered_trees[0]
+        return filtered_targets[0]
 
     def _filter(self, type_str):
-        filtered_trees = [tr for tr in self.trees if tr.tree_type == type_str]
-        return ARIResult(trees=filtered_trees)
+        filtered_targets = [tr for tr in self.targets if tr.target_type == type_str]
+        return ARIResult(targets=filtered_targets)

--- a/ansible_risk_insight/risk_detector.py
+++ b/ansible_risk_insight/risk_detector.py
@@ -19,7 +19,7 @@ import os
 import logging
 from typing import List
 
-from .models import AnsibleRunContext, ARIResult, TreeResult, NodeResult, RuleResult, Rule
+from .models import AnsibleRunContext, ARIResult, TargetResult, NodeResult, RuleResult, Rule
 from .keyutil import detect_type, key_delimiter
 from .analyzer import load_taskcalls_in_trees
 from .utils import load_classes_in_dir
@@ -83,9 +83,9 @@ def detect(contexts: List[AnsibleRunContext], rules_dir: str = ""):
         tree_root_type = detect_type(tree_root_key)
         tree_root_name = key2name(tree_root_key)
 
-        t_result = TreeResult(
-            tree_type=tree_root_type,
-            tree_name=tree_root_name,
+        t_result = TargetResult(
+            target_type=tree_root_type,
+            target_name=tree_root_name,
         )
 
         is_playbook = tree_root_type == "playbook"
@@ -118,7 +118,7 @@ def detect(contexts: List[AnsibleRunContext], rules_dir: str = ""):
                     r_result.matched = matched
                 n_result.rules.append(r_result)
             t_result.nodes.append(n_result)
-        ari_result.trees.append(t_result)
+        ari_result.targets.append(t_result)
 
         do_report = False
         output_dict = {}

--- a/ansible_risk_insight/rules/P001_module_name_validation.py
+++ b/ansible_risk_insight/rules/P001_module_name_validation.py
@@ -68,12 +68,12 @@ class ModuleNameValidationRule(Rule):
             if correct_fqcn != task.spec.module or not_exist:
                 need_correction = True
 
-            task.set_annotation("module.suggested_fqcn", suggested_fqcns)
-            task.set_annotation("module.suggested_dependency", suggested_dependency)
-            task.set_annotation("module.resolved_fqcn", task.spec.resolved_name)
-            task.set_annotation("module.wrong_module_name", wrong_module_name)
-            task.set_annotation("module.not_exist", not_exist)
-            task.set_annotation("module.correct_fqcn", correct_fqcn)
-            task.set_annotation("module.need_correction", need_correction)
+            task.set_annotation("module.suggested_fqcn", suggested_fqcns, rule_id=self.rule_id)
+            task.set_annotation("module.suggested_dependency", suggested_dependency, rule_id=self.rule_id)
+            task.set_annotation("module.resolved_fqcn", task.spec.resolved_name, rule_id=self.rule_id)
+            task.set_annotation("module.wrong_module_name", wrong_module_name, rule_id=self.rule_id)
+            task.set_annotation("module.not_exist", not_exist, rule_id=self.rule_id)
+            task.set_annotation("module.correct_fqcn", correct_fqcn, rule_id=self.rule_id)
+            task.set_annotation("module.need_correction", need_correction, rule_id=self.rule_id)
 
         return None

--- a/ansible_risk_insight/rules/P002_module_argument_key_validation.py
+++ b/ansible_risk_insight/rules/P002_module_argument_key_validation.py
@@ -94,12 +94,12 @@ class ModuleArgumentKeyValidationRule(Rule):
                     }
                 )
 
-            task.set_annotation("module.wrong_arg_keys", wrong_keys)
-            task.set_annotation("module.available_arg_keys", available_keys)
-            task.set_annotation("module.required_arg_keys", required_keys)
-            task.set_annotation("module.missing_required_arg_keys", missing_required_keys)
-            task.set_annotation("module.available_args", available_args)
-            task.set_annotation("module.used_alias_and_real_keys", used_alias_and_real_keys)
+            task.set_annotation("module.wrong_arg_keys", wrong_keys, rule_id=self.rule_id)
+            task.set_annotation("module.available_arg_keys", available_keys, rule_id=self.rule_id)
+            task.set_annotation("module.required_arg_keys", required_keys, rule_id=self.rule_id)
+            task.set_annotation("module.missing_required_arg_keys", missing_required_keys, rule_id=self.rule_id)
+            task.set_annotation("module.available_args", available_args, rule_id=self.rule_id)
+            task.set_annotation("module.used_alias_and_real_keys", used_alias_and_real_keys, rule_id=self.rule_id)
 
         # TODO: find duplicate keys
 

--- a/ansible_risk_insight/rules/P003_module_argument_value_validation.py
+++ b/ansible_risk_insight/rules/P003_module_argument_value_validation.py
@@ -86,8 +86,8 @@ class ModuleArgumentValueValidationRule(Rule):
                     if unknown_type_val:
                         unknown_type_values.append(d)
 
-            task.set_annotation("module.wrong_arg_values", wrong_values)
-            task.set_annotation("module.unknown_type_values", wrong_values)
+            task.set_annotation("module.wrong_arg_values", wrong_values, rule_id=self.rule_id)
+            task.set_annotation("module.unknown_type_values", wrong_values, rule_id=self.rule_id)
 
         # TODO: find duplicate keys
 

--- a/ansible_risk_insight/rules/P004_variable_validation.py
+++ b/ansible_risk_insight/rules/P004_variable_validation.py
@@ -54,7 +54,7 @@ class VariableValidationRule(Rule):
                     if v_name.startswith("item."):
                         unnecessary_loop.append({"name": v_name, "suggested": v_name.replace("item.", "")})
 
-        task.set_annotation("variable.undefined_vars", undefined_variables)
-        task.set_annotation("variable.unnecessary_loop_vars", unnecessary_loop)
+        task.set_annotation("variable.undefined_vars", undefined_variables, rule_id=self.rule_id)
+        task.set_annotation("variable.unnecessary_loop_vars", unnecessary_loop, rule_id=self.rule_id)
 
         return None

--- a/ansible_risk_insight/scanner.py
+++ b/ansible_risk_insight/scanner.py
@@ -791,9 +791,9 @@ class ARIScanner(object):
             self.register_findings_to_ram(scandata.findings)
 
         if scandata.out_dir is not None and scandata.out_dir != "":
-            self.save_findings(scandata.findings, scandata.out_dir)
+            self.save_rule_result(scandata.findings, scandata.out_dir)
             if not self.silent:
-                print("The findings are saved at {}".format(scandata.out_dir))
+                print("The rule result is saved at {}".format(scandata.out_dir))
 
         if not self.silent:
             summary = summarize_findings(scandata.findings, self.show_all)
@@ -829,6 +829,15 @@ class ARIScanner(object):
 
     def save_findings(self, findings: Findings, out_dir: str):
         self.ram_client.save_findings(findings, out_dir)
+
+    def save_rule_result(self, findings: Findings, out_dir: str):
+        if out_dir == "":
+            raise ValueError("output dir must be a non-empty value")
+
+        if not os.path.exists(out_dir):
+            os.makedirs(out_dir, exist_ok=True)
+
+        findings.save_rule_result(fpath=os.path.join(out_dir, "rule_result.json"))
 
     def get_last_scandata(self):
         return self._current


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

- `--out-dir` option will be used for the rule evaluation result instead of findings data
- findings will be treated as internal data in ARI after this change, and it will not be shown to a user normally
- change a class name TreeResult to TargetResult to make it more sense