### PR TITLE
respect rule precedence more than rules config of ARIScanner

### DIFF
--- a/ansible_risk_insight/risk_detector.py
+++ b/ansible_risk_insight/risk_detector.py
@@ -48,8 +48,11 @@ def load_rules(rules_dir: str = "", rule_id_list: list = []):
                 _rules.append(_rule)
             except Exception:
                 raise ValueError(f"failed to load a rule: {r}")
+
+    # sort by rule_id
     _rules = sorted(_rules, key=lambda r: int(r.rule_id[-3:]))
-    _rules = sorted(_rules, key=lambda r: r.precedence)
+
+    # sort by `rules` configuration for ARIScanner
     if rule_id_list:
 
         def index(_list, x):
@@ -59,6 +62,9 @@ def load_rules(rules_dir: str = "", rule_id_list: list = []):
                 return len(_list)
 
         _rules = sorted(_rules, key=lambda r: index(rule_id_list, r))
+
+    # sort by precedence
+    _rules = sorted(_rules, key=lambda r: r.precedence)
 
     return _rules
 


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

- respect rule precedence more than rules config
  - Even if ARIScanner was initialized with rules config like `rules=[R001, R002, R003]`, rule precedence is always more respected than the order in this config to determine the rule evaluation order.