### PR TITLE
add a primitive annotation to find a module arg value with undefined variables

### DIFF
--- a/ansible_risk_insight/models.py
+++ b/ansible_risk_insight/models.py
@@ -526,10 +526,15 @@ class Arguments(object):
             return None
 
         _vars = []
+        sub_type = ArgumentsType.SIMPLE
         if isinstance(sub_raw, str):
             for v in self.vars:
                 if v.name in sub_raw:
                     _vars.append(v)
+        elif isinstance(sub_raw, list):
+            sub_type = ArgumentsType.LIST
+        elif isinstance(sub_raw, dict):
+            sub_type = ArgumentsType.DICT
         is_mutable = False
         for v in _vars:
             if v.is_mutable:
@@ -537,7 +542,7 @@ class Arguments(object):
                 break
 
         return Arguments(
-            type=ArgumentsType.SIMPLE,
+            type=sub_type,
             raw=sub_raw,
             vars=_vars,
             resolved=self.resolved,
@@ -1273,11 +1278,14 @@ class MutableContent(object):
         self._yaml = self._task_spec.yaml()
         return self
 
-    def replace_module_arg_value(self, key: str, old_value: any, new_value: any):
-        if key in self._task_spec.module_options:
-            value = self._task_spec.module_options[key]
+    def replace_module_arg_value(self, key: str = "", old_value: any = None, new_value: any = None):
+        for k in self._task_spec.module_options:
+            # if `key` is specified, skip other keys
+            if key and k != key:
+                continue
+            value = self._task_spec.module_options[k]
             if type(value) == type(old_value) and value == old_value:
-                self._task_spec.module_options[key] = new_value
+                self._task_spec.module_options[k] = new_value
         self._yaml = self._task_spec.yaml()
         return self
 

--- a/ansible_risk_insight/rules/P003_module_argument_value_validation.py
+++ b/ansible_risk_insight/rules/P003_module_argument_value_validation.py
@@ -91,9 +91,10 @@ class ModuleArgumentValueValidationRule(Rule):
                         unknown_type_values.append(d)
 
                     sub_args = task.args.get(key)
-                    undefined_vars = [v.name for v in sub_args.vars if v.type == VariableType.Unknown]
-                    if undefined_vars:
-                        undefined_values.append({"key": key, "value": raw_value, "undefined_variables": undefined_vars})
+                    if sub_args:
+                        undefined_vars = [v.name for v in sub_args.vars if v and v.type == VariableType.Unknown]
+                        if undefined_vars:
+                            undefined_values.append({"key": key, "value": raw_value, "undefined_variables": undefined_vars})
 
             task.set_annotation("module.wrong_arg_values", wrong_values, rule_id=self.rule_id)
             task.set_annotation("module.undefined_values", undefined_values, rule_id=self.rule_id)


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

- update a primitive rule to add 1 annotation for detecting a module arg value with undefined variables