### PR TITLE
add --no-module-spec option for ram generation without ansible-doc

### DIFF
--- a/ansible_risk_insight/cli/ram/generate.py
+++ b/ansible_risk_insight/cli/ram/generate.py
@@ -28,6 +28,7 @@ class RAMGenerateCLI:
         parser.add_argument("action", help="action for RAM command or target_name of search action")
         parser.add_argument("-f", "--file", help='target list like "collection community.general"')
         parser.add_argument("-r", "--resume", help="line number to resume scanning")
+        parser.add_argument("--no-module-spec", action="store_true", help="if True, ansible-doc is not used")
         parser.add_argument("--download-only", action="store_true", help="if True, just download the content")
         args = parser.parse_args()
         self.args = args
@@ -53,5 +54,6 @@ class RAMGenerateCLI:
             target_list=target_list,
             resume=resume,
             download_only=args.download_only,
+            no_module_spec=args.no_module_spec,
         )
         ram_generator.run()

--- a/ansible_risk_insight/ram_generator.py
+++ b/ansible_risk_insight/ram_generator.py
@@ -25,16 +25,22 @@ class RiskAssessmentModelGenerator(object):
     _resume: int = -1
     _update: bool = False
 
-    def __init__(self, target_list=[], resume=-1, update=False, parallel=True, download_only=False):
+    def __init__(self, target_list=[], resume=-1, update=False, parallel=True, download_only=False, no_module_spec=False):
         self._queue = target_list
         self._resume = resume
         self._update = update
         self._parallel = parallel
         self._download_only = download_only
+        self._no_module_spec = no_module_spec
+
+        use_ansible_doc = True
+        if self._no_module_spec:
+            use_ansible_doc = False
 
         self._scanner = ARIScanner(
             root_dir=config.data_dir,
             silent=True,
+            use_ansible_doc=use_ansible_doc,
         )
 
     def run(self):


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

- add --no-module-spec option for ram generation without ansible-doc