### PR TITLE
support taskfile input both for CLI and for SDK

### DIFF
--- a/ansible_risk_insight/__init__.py
+++ b/ansible_risk_insight/__init__.py
@@ -18,7 +18,7 @@ import sys
 from .cli import ARICLI
 from .cli.ram import RAMCLI
 
-ari_actions = ["project", "playbook", "collection", "role"]
+ari_actions = ["project", "playbook", "collection", "role", "taskfile"]
 ram_actions = ["ram"]
 
 all_actions = ari_actions + ram_actions
@@ -33,6 +33,7 @@ def main():
         print("   collection   scan a collection (e.g. `ari collection collection.name` )")
         print("   role         scan a role (e.g. `ari role role.name` )")
         print("   project      scan a project (e.g. `ari project path/to/project`)")
+        print("   taskfile     scan a taskfile (e.g. `ari taskfile path/to/taskfile.yml`)")
         print("   ram          operate the backend data (e.g. `ari ram generate -f input.txt`)")
         sys.exit()
 

--- a/ansible_risk_insight/cli/__init__.py
+++ b/ansible_risk_insight/cli/__init__.py
@@ -37,9 +37,10 @@ class ARICLI:
             action="store_true",
             help="enable file save under ARI_DATA_DIR (default=/tmp/ari-data)",
         )
-        parser.add_argument("target_type", help="Content type", choices={"project", "role", "collection", "playbook"})
+        parser.add_argument("target_type", help="Content type", choices={"project", "role", "collection", "playbook", "taskfile"})
         parser.add_argument("target_name", help="Name")
         parser.add_argument("--playbook-only", action="store_true", help="if true, don't load playbooks/roles arround the specified playbook")
+        parser.add_argument("--taskfile-only", action="store_true", help="if true, don't load playbooks/roles arround the specified taskfile")
         parser.add_argument("--skip-install", action="store_true", help="if true, skip install for the specified target")
         parser.add_argument("--dependency-dir", nargs="?", help="path to a directory that have dependencies for the target")
         parser.add_argument("--collection-name", nargs="?", help="if provided, use it as a collection name")
@@ -76,7 +77,7 @@ class ARICLI:
         is_local = False
         if args.target_type in ["collection", "role"] and is_local_path(target_name):
             is_local = True
-        if args.target_type in ["project", "playbook"] and not is_url(target_name):
+        if args.target_type in ["project", "playbook", "taskfile"] and not is_url(target_name):
             is_local = True
 
         if is_local and not collection_name and not role_name:
@@ -142,5 +143,6 @@ class ARICLI:
             role_name=role_name,
             source_repository=args.source,
             playbook_only=args.playbook_only,
+            taskfile_only=args.taskfile_only,
             out_dir=args.out_dir,
         )

--- a/ansible_risk_insight/dependency_dir_preparator.py
+++ b/ansible_risk_insight/dependency_dir_preparator.py
@@ -139,7 +139,7 @@ class DependencyDirPreparator(object):
             pass
         else:
             # if a project target is a local path, then skip install
-            if self.target_type in [LoadType.PROJECT, LoadType.PLAYBOOK] and not is_url(self.target_name):
+            if self.target_type in [LoadType.PROJECT, LoadType.PLAYBOOK, LoadType.TASKFILE] and not is_url(self.target_name):
                 root_install = False
 
             # if a collection/role is a local path, then skip install (require MANIFEST.json or meta/main.yml to get the actual name)

--- a/ansible_risk_insight/finder.py
+++ b/ansible_risk_insight/finder.py
@@ -83,30 +83,39 @@ def find_module_name(data_block):
     return ""
 
 
-def get_task_blocks(fpath="", task_dict_list=None):
+def get_task_blocks(fpath="", yaml_str="", task_dict_list=None):
     d = None
-    if fpath != "":
+    yaml_lines = ""
+    if yaml_str:
+        try:
+            d = yaml.safe_load(yaml_str)
+            yaml_lines = yaml_str
+        except Exception as e:
+            logger.debug("failed to load this yaml string to get task blocks; {}".format(e.args[0]))
+            return None, None
+    elif fpath:
         if not os.path.exists(fpath):
-            return None
+            return None, None
         with open(fpath, "r") as file:
             try:
-                d = yaml.safe_load(file)
+                yaml_lines = file.read()
+                d = yaml.safe_load(yaml_lines)
             except Exception as e:
                 logger.debug("failed to load this yaml file to get task blocks; {}".format(e.args[0]))
-                return None
+                return None, None
     elif task_dict_list is not None:
         d = task_dict_list
     else:
-        return None
+        return None, None
     if d is None:
-        return None
+        return None, None
     if not isinstance(d, list):
-        return None
+        return None, None
     tasks = []
     for task_dict in d:
         task_dict_loop = flatten_block_tasks(task_dict)
         tasks.extend(task_dict_loop)
-    return tasks
+    return tasks, yaml_lines
 
 
 # extract all tasks by flattening block tasks recursively

--- a/ansible_risk_insight/model_loader.py
+++ b/ansible_risk_insight/model_loader.py
@@ -56,6 +56,7 @@ from .finder import (
 )
 from .utils import (
     split_target_playbook_fullpath,
+    split_target_taskfile_fullpath,
     get_module_documentations_by_ansible_doc,
     get_documentation_in_module_file,
     get_class_by_arg_type,
@@ -92,6 +93,7 @@ def load_repository(
     my_collection_name="",
     basedir="",
     target_playbook_path="",
+    target_taskfile_path="",
     use_ansible_doc=True,
     skip_playbook_format_error=True,
     skip_task_format_error=True,
@@ -161,6 +163,7 @@ def load_repository(
     repoObj.installed_collections_path = installed_collections_path
     repoObj.installed_roles_path = installed_roles_path
     repoObj.target_playbook_path = target_playbook_path
+    repoObj.target_taskfile_path = target_taskfile_path
     logger.debug("done")
 
     return repoObj
@@ -267,7 +270,7 @@ def load_play(
     collection_name="",
     parent_key="",
     parent_local_key="",
-    playbook_yaml="",
+    yaml_lines="",
     basedir="",
     skip_task_format_error=True,
 ):
@@ -320,7 +323,7 @@ def load_play(
                         play_index=index,
                         parent_key=pbObj.key,
                         parent_local_key=pbObj.local_key,
-                        playbook_yaml=playbook_yaml,
+                        yaml_lines=yaml_lines,
                         basedir=basedir,
                     )
                     pre_tasks.append(t)
@@ -351,7 +354,7 @@ def load_play(
                         play_index=index,
                         parent_key=pbObj.key,
                         parent_local_key=pbObj.local_key,
-                        playbook_yaml=playbook_yaml,
+                        yaml_lines=yaml_lines,
                         basedir=basedir,
                     )
                     tasks.append(t)
@@ -382,7 +385,7 @@ def load_play(
                         play_index=index,
                         parent_key=pbObj.key,
                         parent_local_key=pbObj.local_key,
-                        playbook_yaml=playbook_yaml,
+                        yaml_lines=yaml_lines,
                         basedir=basedir,
                     )
                     post_tasks.append(t)
@@ -417,7 +420,7 @@ def load_play(
                         role_name=role_name,
                         collection_name=collection_name,
                         collections_in_play=collections_in_play,
-                        playbook_yaml=playbook_yaml,
+                        yaml_lines=yaml_lines,
                         basedir=basedir,
                     )
                     roles.append(rip)
@@ -548,7 +551,7 @@ def load_playbook(path="", yaml_str="", role_name="", collection_name="", basedi
                 collection_name=collection_name,
                 parent_key=pbObj.key,
                 parent_local_key=pbObj.local_key,
-                playbook_yaml=yaml_str,
+                yaml_lines=yaml_str,
                 basedir=basedir,
                 skip_task_format_error=skip_task_format_error,
             )
@@ -1058,13 +1061,13 @@ def load_task(
     play_index=-1,
     parent_key="",
     parent_local_key="",
-    playbook_yaml="",
+    yaml_lines="",
     basedir="",
 ):
 
     taskObj = Task()
     fullpath = ""
-    if playbook_yaml:
+    if yaml_lines:
         fullpath = path
     else:
         if os.path.exists(path) and path != "" and path != ".":
@@ -1093,9 +1096,7 @@ def load_task(
         else:
             task_options.update({k: v})
 
-    taskObj.set_yaml_lines(
-        fullpath=fullpath, playbook_yaml=playbook_yaml, task_name=task_name, module_name=module_name, module_options=module_options
-    )
+    taskObj.set_yaml_lines(fullpath=fullpath, yaml_lines=yaml_lines, task_name=task_name, module_name=module_name, module_options=module_options)
 
     # module_options can be passed as a string like below
     #
@@ -1203,18 +1204,20 @@ def load_task(
     return taskObj
 
 
-def load_taskfile(path, role_name="", collection_name="", basedir="", skip_task_format_error=True):
+def load_taskfile(path, yaml_str="", role_name="", collection_name="", basedir="", skip_task_format_error=True):
     tfObj = TaskFile()
-
     fullpath = ""
-    if os.path.exists(path) and path != "" and path != ".":
+    if yaml_str:
         fullpath = path
-    if os.path.exists(os.path.join(basedir, path)):
-        fullpath = os.path.normpath(os.path.join(basedir, path))
-    if fullpath == "":
-        raise ValueError("file not found")
-    if not fullpath.endswith(".yml") and not fullpath.endswith(".yaml"):
-        raise ValueError('task yaml file must be ".yml" or ".yaml"')
+    else:
+        if os.path.exists(path) and path != "" and path != ".":
+            fullpath = path
+        if os.path.exists(os.path.join(basedir, path)):
+            fullpath = os.path.normpath(os.path.join(basedir, path))
+        if fullpath == "":
+            raise ValueError("file not found")
+        if not fullpath.endswith(".yml") and not fullpath.endswith(".yaml"):
+            raise ValueError('task yaml file must be ".yml" or ".yaml"')
     tfObj.name = os.path.basename(fullpath)
     defined_in = fullpath
     if basedir != "":
@@ -1229,7 +1232,7 @@ def load_taskfile(path, role_name="", collection_name="", basedir="", skip_task_
         tfObj.collection = collection_name
     tfObj.set_key()
 
-    task_dicts = get_task_blocks(fpath=fullpath)
+    task_dicts, yaml_lines = get_task_blocks(fpath=fullpath, yaml_str=yaml_str)
     if task_dicts is None:
         return tfObj
     tasks = []
@@ -1241,6 +1244,7 @@ def load_taskfile(path, role_name="", collection_name="", basedir="", skip_task_
                 t_dict,
                 role_name,
                 collection_name,
+                yaml_lines=yaml_lines,
                 parent_key=tfObj.key,
                 parent_local_key=tfObj.local_key,
                 basedir=basedir,
@@ -1255,6 +1259,9 @@ def load_taskfile(path, role_name="", collection_name="", basedir="", skip_task_
         except Exception:
             logger.exception("error while loading the task at {}, index: {}".format(fullpath, i))
     tfObj.tasks = tasks
+
+    if yaml_lines:
+        tfObj.yaml_lines = yaml_lines
 
     return tfObj
 
@@ -1432,6 +1439,17 @@ def load_object(loadObj):
             obj = load_playbook(path=target_playbook_path, yaml_str=loadObj.playbook_yaml, basedir=basedir)
         else:
             obj = load_repository(path=basedir, basedir=basedir, target_playbook_path=target_playbook_path, load_children=False)
+    elif target_type == LoadType.TASKFILE:
+        basedir = ""
+        target_taskfile_path = ""
+        if loadObj.taskfile_yaml:
+            target_taskfile_path = path
+        else:
+            basedir, target_taskfile_path = split_target_taskfile_fullpath(path)
+        if loadObj.taskfile_only:
+            obj = load_taskfile(path=target_taskfile_path, yaml_str=loadObj.taskfile_yaml, basedir=basedir)
+        else:
+            obj = load_repository(path=basedir, basedir=basedir, target_taskfile_path=target_taskfile_path, load_children=False)
     elif target_type == LoadType.PROJECT:
         obj = load_repository(path=path, basedir=path, load_children=False)
 
@@ -1448,6 +1466,8 @@ def load_object(loadObj):
         loadObj.roles = [obj.defined_in]
     elif target_type == LoadType.PLAYBOOK and loadObj.playbook_only:
         loadObj.playbooks = [obj.defined_in]
+    elif target_type == LoadType.TASKFILE and loadObj.taskfile_only:
+        loadObj.taskfiles = [obj.defined_in]
 
     loadObj.timestamp = datetime.datetime.utcnow().isoformat()
 

--- a/ansible_risk_insight/models.py
+++ b/ansible_risk_insight/models.py
@@ -108,6 +108,7 @@ class LoadType:
     COLLECTION = "collection"
     ROLE = "role"
     PLAYBOOK = "playbook"
+    TASKFILE = "taskfile"
     UNKNOWN = "unknown"
 
 
@@ -119,6 +120,8 @@ class Load(JSONSerializable):
     loader_version: str = ""
     playbook_yaml: str = ""
     playbook_only: bool = False
+    taskfile_yaml: str = ""
+    taskfile_only: bool = False
     timestamp: str = ""
 
     # the following variables are list of paths; not object
@@ -1081,15 +1084,15 @@ class Task(Object, Resolvable):
     # candidates of resovled_name
     possible_candidates: list = field(default_factory=list)
 
-    def set_yaml_lines(self, fullpath="", playbook_yaml="", task_name="", module_name="", module_options=None):
+    def set_yaml_lines(self, fullpath="", yaml_lines="", task_name="", module_name="", module_options=None):
         if not module_name:
             return
         if not task_name and not module_options:
             return
         found_line_num = -1
         lines = []
-        if playbook_yaml:
-            lines = playbook_yaml.splitlines()
+        if yaml_lines:
+            lines = yaml_lines.splitlines()
         else:
             lines = open(fullpath, "r").read().splitlines()
         for i, line in enumerate(lines):
@@ -1754,6 +1757,9 @@ class Repository(Object, Resolvable):
     # for playbook scan
     target_playbook_path: str = ""
 
+    # for taskfile scan
+    target_taskfile_path: str = ""
+
     requirements: dict = field(default_factory=dict)
 
     installed_collections_path: str = ""
@@ -2011,7 +2017,7 @@ class NodeResult(JSONSerializable):
 
 @dataclass
 class TargetResult(JSONSerializable):
-    target_type: str = ""  # playbook or role
+    target_type: str = ""  # playbook, role or taskfile
     target_name: str = ""
     nodes: List[NodeResult] = field(default_factory=list)
 
@@ -2089,7 +2095,7 @@ class ARIResult(JSONSerializable):
             return self._find_by_name(name)
 
         if yaml_str:
-            return self._find_by_yaml_str(yaml_str)
+            return self._find_by_yaml_str(yaml_str, "playbook")
 
         return None
 
@@ -2099,17 +2105,34 @@ class ARIResult(JSONSerializable):
     def role(self, name):
         return self._find_by_name(name)
 
+    def taskfiles(self):
+        return self._filter("taskfile")
+
+    def taskfile(self, name="", path="", yaml_str=""):
+        if name:
+            return self._find_by_name(name)
+
+        # TODO: use path correctly
+        if path:
+            name = os.path.basename(path)
+            return self._find_by_name(name)
+
+        if yaml_str:
+            return self._find_by_yaml_str(yaml_str, "taskfile")
+
+        return None
+
     def _find_by_name(self, name):
         filtered_targets = [tr for tr in self.targets if tr.target_name == name]
         if not filtered_targets:
             return None
         return filtered_targets[0]
 
-    def _find_by_yaml_str(self, yaml_str):
-        playbook_only_result = self._filter("playbook")
-        if not playbook_only_result:
+    def _find_by_yaml_str(self, yaml_str, type_str):
+        type_only_result = self._filter(type_str)
+        if not type_only_result:
             return None
-        filtered_targets = [tr for tr in playbook_only_result.targets if tr.nodes and tr.nodes[0].node.spec.yaml_lines == yaml_str]
+        filtered_targets = [tr for tr in type_only_result.targets if tr.nodes and tr.nodes[0].node.spec.yaml_lines == yaml_str]
         if not filtered_targets:
             return None
         return filtered_targets[0]

--- a/ansible_risk_insight/risk_assessment_model.py
+++ b/ansible_risk_insight/risk_assessment_model.py
@@ -76,7 +76,7 @@ class RAMClient(object):
     def make_findings_dir_path(self, type, name, version, hash):
         type_root = type + "s"
         dir_name = name
-        if type in [LoadType.PROJECT, LoadType.PLAYBOOK]:
+        if type in [LoadType.PROJECT, LoadType.PLAYBOOK, LoadType.TASKFILE]:
             dir_name = escape_url(name)
         ver_str = version if version != "" else "unknown"
         hash_str = hash if hash != "" else "unknown"
@@ -680,6 +680,9 @@ class RAMClient(object):
         if not target_type or target_type == "playbook":
             e_target_name = escape_url(target_name)
             search_patterns.append(os.path.join(self.root_dir, "playbooks", "findings", e_target_name, target_version, "*", "findings.json"))
+        if not target_type or target_type == "taskfile":
+            e_target_name = escape_url(target_name)
+            search_patterns.append(os.path.join(self.root_dir, "taskfiles", "findings", e_target_name, target_version, "*", "findings.json"))
         found_path_list = safe_glob(search_patterns)
         latest_findings_path = ""
         if len(found_path_list) == 1:

--- a/ansible_risk_insight/scanner.py
+++ b/ansible_risk_insight/scanner.py
@@ -54,6 +54,7 @@ from .utils import (
     summarize_findings,
     summarize_findings_data,
     split_target_playbook_fullpath,
+    split_target_taskfile_fullpath,
 )
 
 
@@ -144,6 +145,9 @@ class SingleScan(object):
     target_playbook_name: str = None
     playbook_yaml: str = ""
     playbook_only: bool = False
+    target_taskfile_name: str = None
+    taskfile_yaml: str = ""
+    taskfile_only: bool = False
 
     skip_playbook_format_error: bool = (True,)
     skip_task_format_error: bool = (True,)
@@ -230,7 +234,7 @@ class SingleScan(object):
                 ),
             }
 
-        elif self.type == LoadType.PROJECT or self.type == LoadType.PLAYBOOK:
+        elif self.type == LoadType.PROJECT or self.type == LoadType.PLAYBOOK or self.type == LoadType.TASKFILE:
             type_root = self.type + "s"
             proj_name = escape_url(self.name)
             if self.type == LoadType.PLAYBOOK:
@@ -238,6 +242,11 @@ class SingleScan(object):
                     self.target_playbook_name = self.name
                 else:
                     _, self.target_playbook_name = split_target_playbook_fullpath(self.name)
+            elif self.type == LoadType.TASKFILE:
+                if self.taskfile_yaml:
+                    self.target_taskfile_name = self.name
+                else:
+                    _, self.target_taskfile_name = split_target_taskfile_fullpath(self.name)
             self.__path_mappings = {
                 "src": os.path.join(self.root_dir, type_root, proj_name, "src"),
                 "root_definitions": os.path.join(
@@ -272,6 +281,13 @@ class SingleScan(object):
             self.playbook_only = True
             if not self.name:
                 self.name = "__in_memory__"
+                self.target_playbook_name = self.name
+
+        if self.taskfile_yaml:
+            self.taskfile_only = True
+            if not self.name:
+                self.name = "__in_memory__"
+                self.target_taskfile_name = self.name
 
     def make_target_path(self, typ, target_name, dep_dir=""):
         target_path = ""
@@ -309,6 +325,11 @@ class SingleScan(object):
             else:
                 target_path = target_name
         elif typ == LoadType.PLAYBOOK:
+            if is_url(target_name):
+                target_path = os.path.join(self.get_src_root(), escape_url(target_name))
+            else:
+                target_path = target_name
+        elif typ == LoadType.TASKFILE:
             if is_url(target_name):
                 target_path = os.path.join(self.get_src_root(), escape_url(target_name))
             else:
@@ -359,7 +380,7 @@ class SingleScan(object):
 
         loader_version = get_loader_version()
 
-        if not os.path.exists(target_path) and not self.playbook_yaml:
+        if not os.path.exists(target_path) and not self.playbook_yaml and not self.taskfile_yaml:
             raise ValueError("No such file or directory: {}".format(target_path))
         if not self.silent:
             logger.debug(f"target_name: {target_name}")
@@ -373,6 +394,8 @@ class SingleScan(object):
             loader_version=loader_version,
             playbook_yaml=self.playbook_yaml,
             playbook_only=self.playbook_only,
+            taskfile_yaml=self.taskfile_yaml,
+            taskfile_only=self.taskfile_only,
         )
         load_object(ld)
         return ld
@@ -425,7 +448,7 @@ class SingleScan(object):
             if target_path == "":
                 target_path = self.get_source_path(ext_type, ext_name)
             root_load_data = self.create_load_file(ext_type, ext_name, target_path)
-        elif self.type in [LoadType.PROJECT, LoadType.PLAYBOOK]:
+        elif self.type in [LoadType.PROJECT, LoadType.PLAYBOOK, LoadType.TASKFILE]:
             src_root = self.get_src_root()
             if target_path == "":
                 target_path = os.path.join(src_root, escape_url(self.name))
@@ -477,7 +500,7 @@ class SingleScan(object):
 
     def construct_trees(self, ram_client=None):
         trees, additional, extra_requirements, resolve_failures = tree(
-            self.root_definitions, self.ext_definitions, ram_client, self.target_playbook_name
+            self.root_definitions, self.ext_definitions, ram_client, self.target_playbook_name, self.target_taskfile_name
         )
         self.trees = trees
         self.additional = additional
@@ -688,6 +711,8 @@ class ARIScanner(object):
         source_repository: str = "",
         playbook_yaml: str = "",
         playbook_only: bool = False,
+        taskfile_yaml: str = "",
+        taskfile_only: bool = False,
         out_dir: str = "",
     ):
         time_records = {}
@@ -715,6 +740,8 @@ class ARIScanner(object):
             source_repository=source_repository,
             playbook_yaml=playbook_yaml,
             playbook_only=playbook_only,
+            taskfile_yaml=taskfile_yaml,
+            taskfile_only=taskfile_only,
             out_dir=out_dir,
             root_dir=self.root_dir,
             rules_dir=self.rules_dir,
@@ -828,7 +855,7 @@ class ARIScanner(object):
 
         loaded = False
         self.record_begin(time_records, "target_load")
-        if self.read_ram and scandata.type != LoadType.PLAYBOOK:
+        if self.read_ram and scandata.type not in [LoadType.PLAYBOOK, LoadType.TASKFILE]:
             loaded, root_defs = self.load_definitions_from_ram(scandata.type, scandata.name, scandata.version, scandata.hash, allow_unresolved=True)
             logger.debug(f"spec data loaded: {loaded}")
             if loaded:
@@ -962,8 +989,8 @@ class ARIScanner(object):
         time_records[record_name]["elapsed"] = elapsed
 
 
-def tree(root_definitions, ext_definitions, ram_client=None, target_playbook_path=None):
-    tl = TreeLoader(root_definitions, ext_definitions, ram_client, target_playbook_path)
+def tree(root_definitions, ext_definitions, ram_client=None, target_playbook_path=None, target_taskfile_path=None):
+    tl = TreeLoader(root_definitions, ext_definitions, ram_client, target_playbook_path, target_taskfile_path)
     trees, additional = tl.run()
     if trees is None:
         raise ValueError("failed to get trees")

--- a/ansible_risk_insight/utils.py
+++ b/ansible_risk_insight/utils.py
@@ -173,6 +173,16 @@ def split_target_playbook_fullpath(fullpath: str):
     return basedir, target_playbook_path
 
 
+def split_target_taskfile_fullpath(fullpath: str):
+    basedir = os.path.dirname(fullpath)
+    if "/roles/" in fullpath:
+        basedir = fullpath.split("/roles/")[0]
+    target_taskfile_path = fullpath.replace(basedir, "")
+    if target_taskfile_path[0] == "/":
+        target_taskfile_path = target_taskfile_path[1:]
+    return basedir, target_taskfile_path
+
+
 def version_to_num(ver: str):
     if ver == "unknown":
         return 0


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

- support taskfile input both for CLI use and for SDK use
  - only if the specified content is a taskfile, ARI handle the taskfile as a root of call tree. (normally the root is only playbooks or roles)