### PR TITLE
add `replace_module_arg_with_dict` to MutableContent

### DIFF
--- a/ansible_risk_insight/models.py
+++ b/ansible_risk_insight/models.py
@@ -1436,6 +1436,11 @@ class MutableContent(object):
         self._task_spec = new_task
         return self
 
+    def replace_module_arg_with_dict(self, new_dict: dict):
+        self._task_spec.module_options = new_dict
+        self._yaml = self._task_spec.yaml()
+        return self
+
     def yaml(self):
         return self._yaml
 


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

- add `replace_module_arg_with_dict` to MutableContent