### PR TITLE
fix taskfile loading issue for invalid input

### DIFF
--- a/ansible_risk_insight/model_loader.py
+++ b/ansible_risk_insight/model_loader.py
@@ -1235,6 +1235,11 @@ def load_taskfile(path, yaml_str="", role_name="", collection_name="", basedir="
     tfObj.set_key()
 
     task_dicts, yaml_lines = get_task_blocks(fpath=fullpath, yaml_str=yaml_str)
+
+    if yaml_str and not yaml_lines:
+        yaml_lines = yaml_str
+    tfObj.yaml_lines = yaml_lines
+
     if task_dicts is None:
         return tfObj
     tasks = []
@@ -1261,9 +1266,6 @@ def load_taskfile(path, yaml_str="", role_name="", collection_name="", basedir="
         except Exception:
             logger.exception("error while loading the task at {}, index: {}".format(fullpath, i))
     tfObj.tasks = tasks
-
-    if yaml_lines:
-        tfObj.yaml_lines = yaml_lines
 
     return tfObj
 

--- a/ansible_risk_insight/models.py
+++ b/ansible_risk_insight/models.py
@@ -1631,6 +1631,8 @@ class TaskFile(Object, Resolvable):
     role: str = ""
     collection: str = ""
 
+    yaml_lines: str = ""
+
     used_in: list = field(default_factory=list)  # resolved later
 
     annotations: dict = field(default_factory=dict)
@@ -2269,7 +2271,11 @@ class ARIResult(JSONSerializable):
         type_only_result = self._filter(type_str)
         if not type_only_result:
             return None
-        filtered_targets = [tr for tr in type_only_result.targets if tr.nodes and tr.nodes[0].node.spec.yaml_lines == yaml_str]
+        filtered_targets = [
+            tr
+            for tr in type_only_result.targets
+            if tr.nodes and hasattr(tr.nodes[0].node.spec, "yaml_lines") and tr.nodes[0].node.spec.yaml_lines == yaml_str
+        ]
         if not filtered_targets:
             return None
         return filtered_targets[0]


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

- fix taskfile loading issue for invalid input (e.g. taskfile but data is not a list )

```
# taskfile.yml
---
  name: Print hello world     <-- taskfile must be a list, but this is a dict because of missing "-"
  debug:
    msg: "Hello, world!"

```