### PR TITLE
fix to apply spec mutations to the loaded object

### DIFF
--- a/ansible_risk_insight/analyzer.py
+++ b/ansible_risk_insight/analyzer.py
@@ -24,7 +24,7 @@ from .utils import load_classes_in_dir
 
 
 def load_annotators(ctx: AnsibleRunContext = None):
-    _annotator_classes = load_classes_in_dir("annotators", RiskAnnotator, __file__)
+    _annotator_classes, _ = load_classes_in_dir("annotators", RiskAnnotator, __file__)
     _annotators = []
     for a in _annotator_classes:
         try:

--- a/ansible_risk_insight/annotators/risk_annotator_base.py
+++ b/ansible_risk_insight/annotators/risk_annotator_base.py
@@ -38,7 +38,7 @@ class RiskAnnotator(Annotator):
         if dir_path in self.module_annotator_cache:
             return self.module_annotator_cache[dir_path]
 
-        annotator_classes = load_classes_in_dir(dir_path, ModuleAnnotator, __file__)
+        annotator_classes, _ = load_classes_in_dir(dir_path, ModuleAnnotator, __file__)
         module_annotators = []
         for a_c in annotator_classes:
             annotator = a_c(context=self.context)

--- a/ansible_risk_insight/scanner.py
+++ b/ansible_risk_insight/scanner.py
@@ -508,10 +508,11 @@ class SingleScan(object):
         # overwrite the loaded object with the mutated object in spec mutations
         for type_name in self.root_definitions["definitions"]:
             obj_list = self.root_definitions["definitions"][type_name]
-            for obj in obj_list:
+            for i, obj in enumerate(obj_list):
                 key = obj.key
                 if key in self.spec_mutations_from_previous_scan:
-                    obj = self.spec_mutations_from_previous_scan[key].object
+                    mutated_spec = self.spec_mutations_from_previous_scan[key].object
+                    self.root_definitions["definitions"][type_name][i] = mutated_spec
         return
 
     def construct_trees(self, ram_client=None):


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

- fix to apply spec mutations to the loaded object in the second scan
- errors that occurred while applying rules will be reported as rule result instead of raising exceptions