### PR TITLE
add `--include-tests` option to load test contents in collections

### DIFF
--- a/ansible_risk_insight/cli/__init__.py
+++ b/ansible_risk_insight/cli/__init__.py
@@ -48,6 +48,8 @@ class ARICLI:
         parser.add_argument("--source", help="source server name in ansible config file (if empty, use public ansible galaxy)")
         parser.add_argument("--without-ram", action="store_true", help="if true, RAM data is not used and not even updated")
         parser.add_argument("--update-ram", action="store_true", help="if true, RAM data is not used for scan but updated with the scan result")
+        parser.add_argument("--include-tests", action="store_true", help='if true, load test contents in "tests/integration/targets"')
+        parser.add_argument("--objects", action="store_true", help="if true, output objects.json to the output directory")
         parser.add_argument("--show-all", action="store_true", help="if true, show findings even if missing dependencies are found")
         parser.add_argument("--json", help="if specified, show findings in json format")
         parser.add_argument("--yaml", help="if specified, show findings in yaml format")
@@ -144,5 +146,7 @@ class ARICLI:
             source_repository=args.source,
             playbook_only=args.playbook_only,
             taskfile_only=args.taskfile_only,
+            include_test_contents=args.include_tests,
+            objects=args.objects,
             out_dir=args.out_dir,
         )

--- a/ansible_risk_insight/models.py
+++ b/ansible_risk_insight/models.py
@@ -115,6 +115,7 @@ class Load(JSONSerializable):
     playbook_only: bool = False
     taskfile_yaml: str = ""
     taskfile_only: bool = False
+    include_test_contents: bool = False
     timestamp: str = ""
 
     # the following variables are list of paths; not object
@@ -348,6 +349,21 @@ class ModuleMetadata(object):
         mm.version = metadata.get("version", "")
         mm.hash = metadata.get("hash", "")
         return mm
+
+    @staticmethod
+    def from_dict(d: dict):
+        mm = ModuleMetadata()
+        mm.fqcn = d.get("fqcn", "")
+        mm.type = d.get("type", "")
+        mm.name = d.get("name", "")
+        mm.version = d.get("version", "")
+        mm.hash = d.get("hash", "")
+        return mm
+
+    def __eq__(self, mm):
+        if not isinstance(mm, ModuleMetadata):
+            return False
+        return self.fqcn == mm.fqcn and self.name == mm.name and self.type == mm.type and self.version == mm.version and self.hash == mm.hash
 
 
 @dataclass

--- a/ansible_risk_insight/parser.py
+++ b/ansible_risk_insight/parser.py
@@ -74,6 +74,7 @@ class Parser:
                     use_ansible_doc=self.use_ansible_doc,
                     skip_playbook_format_error=self.skip_playbook_format_error,
                     skip_task_format_error=self.skip_task_format_error,
+                    include_test_contents=ld.include_test_contents,
                     load_children=False,
                 )
             except PlaybookFormatError:
@@ -114,6 +115,7 @@ class Parser:
                     use_ansible_doc=self.use_ansible_doc,
                     skip_playbook_format_error=self.skip_playbook_format_error,
                     skip_task_format_error=self.skip_task_format_error,
+                    include_test_contents=ld.include_test_contents,
                 )
             except PlaybookFormatError:
                 if not self.skip_playbook_format_error:
@@ -153,6 +155,7 @@ class Parser:
                         use_ansible_doc=self.use_ansible_doc,
                         skip_playbook_format_error=self.skip_playbook_format_error,
                         skip_task_format_error=self.skip_task_format_error,
+                        include_test_contents=ld.include_test_contents,
                     )
             except PlaybookFormatError:
                 if not self.skip_playbook_format_error:
@@ -187,6 +190,7 @@ class Parser:
                         use_ansible_doc=self.use_ansible_doc,
                         skip_playbook_format_error=self.skip_playbook_format_error,
                         skip_task_format_error=self.skip_task_format_error,
+                        include_test_contents=ld.include_test_contents,
                     )
             except TaskFormatError:
                 if not self.skip_task_format_error:

--- a/ansible_risk_insight/risk_detector.py
+++ b/ansible_risk_insight/risk_detector.py
@@ -36,6 +36,8 @@ def key2name(key: str):
 
 
 def load_rules(rules_dir: str = "", rule_id_list: list = [], fail_on_error: bool = False):
+    if not rules_dir:
+        return []
     rules_dir_list = rules_dir.split(":")
     _rules = []
     for _rules_dir in rules_dir_list:

--- a/ansible_risk_insight/rules/R204_unnecessary_set_fact.py
+++ b/ansible_risk_insight/rules/R204_unnecessary_set_fact.py
@@ -54,6 +54,8 @@ class UnnecessarySetFactRule(Rule):
                 if isinstance(v, str) and "random" in v:
                     is_impure = True
                     current = detail.get("impure_args", [])
+                    if not current:
+                        current = []
                     detail["impure_args"] = current.append(v)
 
         verdict = (


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

- add `--include-tests` option to load test contents in collections
- add `--objects` option to save objects definition
- fix several bugs