### PR TITLE
support module redirect defined in collections

### DIFF
--- a/ansible_risk_insight/model_loader.py
+++ b/ansible_risk_insight/model_loader.py
@@ -1361,6 +1361,14 @@ def load_collection(
         with open(files_file_path, "r") as file:
             colObj.files = json.load(file)
 
+    meta_runtime_file_path = os.path.join(fullpath, "meta", "runtime.yml")
+    if os.path.exists(meta_runtime_file_path):
+        with open(meta_runtime_file_path, "r") as file:
+            try:
+                colObj.meta_runtime = yaml.safe_load(file)
+            except Exception as e:
+                logger.debug("failed to load meta/runtime.yml; {}".format(e.args[0]))
+
     requirements_yml_path = os.path.join(fullpath, "requirements.yml")
     if os.path.exists(requirements_yml_path):
         with open(requirements_yml_path, "r") as file:

--- a/ansible_risk_insight/models.py
+++ b/ansible_risk_insight/models.py
@@ -351,6 +351,16 @@ class ModuleMetadata(object):
         return mm
 
     @staticmethod
+    def from_routing(dst: str, metadata: dict):
+        mm = ModuleMetadata()
+        mm.fqcn = dst
+        mm.type = metadata.get("type", "")
+        mm.name = metadata.get("name", "")
+        mm.version = metadata.get("version", "")
+        mm.hash = metadata.get("hash", "")
+        return mm
+
+    @staticmethod
     def from_dict(d: dict):
         mm = ModuleMetadata()
         mm.fqcn = d.get("fqcn", "")
@@ -374,6 +384,7 @@ class Collection(Object, Resolvable):
     key: str = ""
     local_key: str = ""
     metadata: dict = field(default_factory=dict)
+    meta_runtime: dict = field(default_factory=dict)
     files: dict = field(default_factory=dict)
     playbooks: list = field(default_factory=list)
     taskfiles: list = field(default_factory=list)


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

- support module redirect defined in collections
  - e.g. ec2_group --> amazon.aws.ec2_security_group (defined [here](https://github.com/ansible-collections/amazon.aws/blob/d34cee63b8606628095f1ecd432101fc25f4b43f/meta/runtime.yml#L119-L121))