### PR TITLE
move from gitpackage to pygit2

### DIFF
--- a/ansible_risk_insight/loader.py
+++ b/ansible_risk_insight/loader.py
@@ -17,7 +17,7 @@
 import os
 import pathlib
 import json
-import git
+import pygit2
 import pkg_resources
 from .models import LoadType
 
@@ -60,9 +60,8 @@ def get_loader_version():
     # try to get version from commit ID in source code repository
     try:
         script_dir = pathlib.Path(__file__).parent.resolve()
-        repo = git.Repo(path=script_dir, search_parent_directories=True)
-        sha = repo.head.object.hexsha
-        version = sha
+        repo = pygit2.Repository(script_dir)
+        version = repo.head.target
     except Exception:
         pass
     return version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 dependencies = [
     "gitdb",
-    "GitPython",
+    "pygit2",
     "joblib",
     "jsonpickle",
     "PyYAML",


### PR DESCRIPTION
GitPackage is impacted by the following CVE-2022-24439, ARI doesn't use the
affect method, but the present of the package is enough to raise a warning in
Quay.io vulnerability scanner.

This commit move from GitPackage to pygit2 which provides similar feature set.

Also unkile GitPython, pygit2 doesn't require the presence of the `git` binary.
