### PR TITLE
fix initialization of `sequence` in AnsibleRunContext

### DIFF
--- a/ansible_risk_insight/models.py
+++ b/ansible_risk_insight/models.py
@@ -1533,7 +1533,7 @@ class TaskCall(CallObject, RunTarget):
 
 @dataclass
 class AnsibleRunContext(object):
-    sequence: RunTargetList = None
+    sequence: RunTargetList = field(default_factory=RunTargetList)
     root_key: str = ""
     parent: Object = None
 


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

- fix initialization of `sequence` in AnsibleRunContext

The issue resolved by this PR
https://github.com/ansible/ansible-risk-insight/issues/134