### PR TITLE
remove inappropriate global variables to fix rule test issue

### DIFF
--- a/ansible_risk_insight/model_loader.py
+++ b/ansible_risk_insight/model_loader.py
@@ -1082,14 +1082,18 @@ def load_module(module_file_path, collection_name="", role_name="", basedir="", 
 
 
 builtin_modules_file_name = "ansible_builtin_modules.json"
+builtin_modules = {}
 
 
 def load_builtin_modules():
+    global builtin_modules
+    if builtin_modules:
+        return builtin_modules
     base_path = os.path.dirname(__file__)
     data_path = os.path.join(base_path, builtin_modules_file_name)
     module_list = ObjectList.from_json(fpath=data_path)
-    module_dict = {m.name: m for m in module_list.items}
-    return module_dict
+    builtin_modules = {m.name: m for m in module_list.items}
+    return builtin_modules
 
 
 # modules in a SCM repo should be in `library` dir in the best practice case

--- a/ansible_risk_insight/scanner.py
+++ b/ansible_risk_insight/scanner.py
@@ -211,6 +211,7 @@ class SingleScan(object):
     root_dir: str = ""
     rules_dir: str = ""
     rules: list = field(default_factory=list)
+    rules_cache: list = field(default_factory=list)
     persist_dependency_cache: bool = False
     spec_mutations_from_previous_scan: dict = field(default_factory=dict)
     spec_mutations: dict = field(default_factory=dict)
@@ -627,7 +628,8 @@ class SingleScan(object):
             target_name = self.collection_name
         if self.role_name:
             target_name = self.role_name
-        data_report = detect(self.contexts, rules_dir=self.rules_dir, rules=self.rules)
+        data_report, rules_cache = detect(self.contexts, rules_dir=self.rules_dir, rules=self.rules, rules_cache=self.rules_cache)
+        self.rules_cache = rules_cache
         spec_mutations = data_report.get("spec_mutations", {})
         if spec_mutations:
             self.spec_mutations = spec_mutations
@@ -723,6 +725,7 @@ class ARIScanner(object):
     root_dir: str = ""
     rules_dir: str = ""
     rules: list = field(default_factory=list)
+    rules_cache: list = field(default_factory=list)
 
     ram_client: RAMClient = None
     read_ram: bool = True
@@ -833,6 +836,7 @@ class ARIScanner(object):
             root_dir=self.root_dir,
             rules_dir=self.rules_dir,
             rules=self.rules,
+            rules_cache=self.rules_cache,
             persist_dependency_cache=self.persist_dependency_cache,
             spec_mutations_from_previous_scan=spec_mutations_from_previous_scan,
             use_ansible_doc=self.use_ansible_doc,
@@ -1016,6 +1020,9 @@ class ARIScanner(object):
         self.record_end(time_records, "apply_rules")
         if not self.silent:
             logger.debug("apply_rules() done")
+
+        if scandata.rules_cache:
+            self.rules_cache = scandata.rules_cache
 
         scandata.add_time_records(time_records=time_records)
 

--- a/ansible_risk_insight/tree.py
+++ b/ansible_risk_insight/tree.py
@@ -586,13 +586,7 @@ class TreeLoader(object):
         return None
 
     def add_builtin_modules(self):
-        builtin_module_dict = {}
-        if self.ram_client and self.ram_client.builtin_modules_cache:
-            builtin_module_dict = self.ram_client.builtin_modules_cache
-        else:
-            builtin_module_dict = load_builtin_modules()
-            if self.ram_client:
-                self.ram_client.builtin_modules_cache = builtin_module_dict
+        builtin_module_dict = load_builtin_modules()
         builtin_modules = list(builtin_module_dict.values())
         obj_list = ObjectList(items=builtin_modules)
         self.ext_definitions["modules"].merge(obj_list)


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

- remove inappropriate global variables in package; the following values are managed by ari scanner / ram client
  - rule_cache
  - builtin_modules