### PR TITLE
Fix: multiple modules with same short name but different collections

### DIFF
--- a/ansible_risk_insight/risk_assessment_model.py
+++ b/ansible_risk_insight/risk_assessment_model.py
@@ -420,7 +420,9 @@ class RAMClient(object):
         found_index = None
         if short_name in self.module_index and self.module_index[short_name]:
             from_indices = True
-            found_index = self.module_index[short_name][0]
+            for possible_index in self.module_index[short_name]:
+                if possible_index['fqcn'] == name:
+                    found_index = possible_index
 
         modules_json_list = []
         if from_indices:


### PR DESCRIPTION
Previous code always took the first module returned; but if there are more than one we need to iterate and match on the fqcn
