### PR TITLE
enable rule exception only when a special error is raised

### DIFF
--- a/ansible_risk_insight/models.py
+++ b/ansible_risk_insight/models.py
@@ -52,6 +52,10 @@ class TaskFormatError(Exception):
     pass
 
 
+class FatalRuleResultError(Exception):
+    pass
+
+
 class JSONSerializable(object):
     def dump(self):
         return self.to_json()
@@ -1507,7 +1511,7 @@ class TaskCall(CallObject, RunTarget):
         if cond.type:
             _annotations = [an for an in _annotations if an.type == RiskAnnotation.type and an.risk_type == cond.type]
         if cond.attr_conditions:
-            for (key, val) in cond.attr_conditions:
+            for key, val in cond.attr_conditions:
                 _annotations = [an for an in _annotations if hasattr(an, key) and getattr(an, key) == val]
         if _annotations:
             return _annotations[0]


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

- enable rule exception only when a special error is raised
  - An exception class `FatalRuleResultError` is newly added so that ARI can fail with exception. This is useful for some rules that detect fatal error in input data (e.g. no module name in task)
  - all other exceptions are just stored in `error` attribute of rule result data and ARI never fails