### PR TITLE
fix concurrency issue of yaml parser

### DIFF
--- a/ansible_risk_insight/risk_detector.py
+++ b/ansible_risk_insight/risk_detector.py
@@ -188,7 +188,7 @@ def detect(contexts: List[AnsibleRunContext], rules_dir: str = "", rules: list =
                         r_result.matched = matched
                     r_result.duration = round((time.time() - start_time) * 1000, 6)
                     detail = r_result.get_detail()
-                    fatal = detail.get("fatal", False)
+                    fatal = detail.get("fatal", False) if detail else False
                     if fatal:
                         error = r_result.error or "unknown error"
                         error = f"ARI rule evaluation threw fatal exception: {error}"

--- a/ansible_risk_insight/yaml.py
+++ b/ansible_risk_insight/yaml.py
@@ -15,20 +15,30 @@
 # limitations under the License.
 
 import io
+from contextvars import ContextVar
 from ruamel.yaml import YAML
 
 
-_yaml = YAML(typ="rt", pure=True)
-_yaml.default_flow_style = False
-_yaml.preserve_quotes = True
-_yaml.allow_duplicate_keys = True
+_yaml: ContextVar[YAML] = ContextVar("yaml")
+
+
+def _set_yaml():
+    if not _yaml.get(None):
+        _yaml.set(YAML(typ="rt", pure=True))
+        _yaml.default_flow_style = False
+        _yaml.preserve_quotes = True
+        _yaml.allow_duplicate_keys = True
 
 
 def load(stream: any):
-    return _yaml.load(stream)
+    _set_yaml()
+    yaml = _yaml.get()
+    return yaml.load(stream)
 
 
 def dump(data: any):
+    _set_yaml()
+    yaml = _yaml.get()
     output = io.StringIO()
-    _yaml.dump(data, output)
+    yaml.dump(data, output)
     return output.getvalue()


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

- fix thread safety issue of yaml parser by using `ContextVar` for ruamel.yaml.YAML instance
- fix rule result handling