### PR TITLE
enable to use ansible path

### DIFF
--- a/ansible_risk_insight/scanner.py
+++ b/ansible_risk_insight/scanner.py
@@ -185,6 +185,7 @@ class SingleScan(object):
     __path_mappings: dict = field(default_factory=dict)
 
     install_dependencies: bool = False
+    use_ansible_path: bool = False
 
     dependency_dir: str = ""
     base_dir: str = ""
@@ -399,6 +400,7 @@ class SingleScan(object):
         )
         dep_dirs = ddp.prepare_dir(
             root_install=root_install,
+            use_ansible_path=self.use_ansible_path,
             is_src_installed=self.is_src_installed(),
             cache_enabled=self.use_src_cache,
             cache_dir=os.path.join(self.root_dir, "archives"),
@@ -809,6 +811,7 @@ class ARIScanner(object):
         collection_name: str = "",
         role_name: str = "",
         install_dependencies: bool = True,
+        use_ansible_path: bool = False,
         version: str = "",
         hash: str = "",
         target_path: str = "",
@@ -850,6 +853,7 @@ class ARIScanner(object):
             collection_name=collection_name,
             role_name=role_name,
             install_dependencies=install_dependencies,
+            use_ansible_path=use_ansible_path,
             version=version,
             hash=hash,
             target_path=target_path,
@@ -990,6 +994,7 @@ class ARIScanner(object):
                             target_path=ext_target_path,
                             dependency_dir=scandata.dependency_dir,
                             install_dependencies=False,
+                            use_ansible_path=False,
                             skip_dependency=True,
                             source_repository=scandata.source_repository,
                             include_test_contents=include_test_contents,
@@ -1135,6 +1140,7 @@ class ARIScanner(object):
                     collection_name=collection_name,
                     role_name=role_name,
                     install_dependencies=install_dependencies,
+                    use_ansible_path=use_ansible_path,
                     version=version,
                     hash=hash,
                     target_path=target_path,

--- a/ansible_risk_insight/utils.py
+++ b/ansible_risk_insight/utils.py
@@ -71,9 +71,9 @@ def install_galaxy_target(target, target_type, output_dir, source_repository="",
     target_name = target
     if target_version:
         target_name = f"{target}:{target_version}"
-    logger.debug("exec ansible-galaxy cmd: ansible-galaxy {} install {} {} -p {}".format(target_type, target_name, server_option, output_dir))
+    logger.debug("exec ansible-galaxy cmd: ansible-galaxy {} install {} {} -p {} --force".format(target_type, target_name, server_option, output_dir))
     proc = subprocess.run(
-        "ansible-galaxy {} install {} {} -p {}".format(target_type, target_name, server_option, output_dir),
+        "ansible-galaxy {} install {} {} -p {} --force".format(target_type, target_name, server_option, output_dir),
         shell=True,
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

- enable to use ansible path
  - if `use_ansible_path` is True in `evaluate()` arguments, ARI reads ansible configuration for ansible dir (`~/.ansible` by default) and it tries to find dependency dirs in the ansible directory. This feature is disabled by default.