### PR TITLE
fix wrong yaml instance type

### DIFF
--- a/ansible_risk_insight/yaml.py
+++ b/ansible_risk_insight/yaml.py
@@ -25,7 +25,7 @@ _yaml: ContextVar[YAML] = ContextVar("yaml")
 
 def _set_yaml(force=False):
     if not _yaml.get(None) or force:
-        yaml = YAML(typ="safe", pure=True)
+        yaml = YAML(typ="rt", pure=True)
         yaml.default_flow_style = False
         yaml.preserve_quotes = True
         yaml.allow_duplicate_keys = True


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

- fix wrong yaml instance type (`rt` is a right instance type to use ruamel.yaml functionalities; `safe` is a mode to use PyYAML package instead)