### PR TITLE
support vars files and fix several issues

### DIFF
--- a/ansible_risk_insight/models.py
+++ b/ansible_risk_insight/models.py
@@ -296,6 +296,7 @@ class File(object):
 
     body: str = ""
     data: any = None
+    encrypted: bool = False
     error: str = ""
     label: str = ""
     defined_in: str = ""
@@ -1974,6 +1975,7 @@ class Play(Object, Resolvable):
     collections_in_play: list = field(default_factory=list)
     become: BecomeInfo = None
     variables: dict = field(default_factory=dict)
+    vars_files: list = field(default_factory=list)
 
     task_loading: dict = field(default_factory=dict)
 

--- a/ansible_risk_insight/scanner.py
+++ b/ansible_risk_insight/scanner.py
@@ -847,7 +847,7 @@ class ARIScanner(object):
             elif type == LoadType.TASKFILE:
                 taskfile_yaml = raw_yaml
 
-        if is_local_path(name):
+        if is_local_path(name) and not playbook_yaml and not taskfile_yaml:
             name = os.path.abspath(name)
 
         scandata = SingleScan(


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

- support vars files
- add `encrypted` flag to File object for Vault file
- fix loop handling issue
- fix filepath issue for YAML string scan