### PR TITLE
add --save-only-rule-result option

### DIFF
--- a/ansible_risk_insight/cli/__init__.py
+++ b/ansible_risk_insight/cli/__init__.py
@@ -59,6 +59,9 @@ class ARICLI:
         parser.add_argument("--show-all", action="store_true", help="if true, show findings even if missing dependencies are found")
         parser.add_argument("--json", help="if specified, show findings in json format")
         parser.add_argument("--yaml", help="if specified, show findings in yaml format")
+        parser.add_argument(
+            "--save-only-rule-result", action="store_true", help="if true, save only rule results and remove node details to reduce result file size"
+        )
         parser.add_argument("-o", "--out-dir", help="output directory for the rule evaluation result")
         parser.add_argument(
             "-r", "--rules-dir", help=f"specify custom rule directories. use `-R` instead to ignore default rules in {config.rules_dir}"
@@ -139,6 +142,9 @@ class ARICLI:
         load_all_taskfiles = True
         if args.skip_isolated_taskfiles:
             load_all_taskfiles = False
+        save_only_rule_result = False
+        if args.save_only_rule_result:
+            save_only_rule_result = True
 
         c = ARIScanner(
             root_dir=config.data_dir,
@@ -170,6 +176,7 @@ class ARICLI:
             taskfile_only=args.taskfile_only,
             include_test_contents=args.include_tests,
             load_all_taskfiles=load_all_taskfiles,
+            save_only_rule_result=save_only_rule_result,
             objects=args.objects,
             out_dir=args.out_dir,
         )

--- a/ansible_risk_insight/model_loader.py
+++ b/ansible_risk_insight/model_loader.py
@@ -879,6 +879,7 @@ def load_playbooks(
 
     playbooks = []
     playbook_names = []
+    candidates = sorted(list(set(candidates)))
     for fpath in candidates:
         if could_be_playbook(fpath=fpath) and could_be_playbook_detail(fpath=fpath):
             relative_path = ""

--- a/ansible_risk_insight/risk_detector.py
+++ b/ansible_risk_insight/risk_detector.py
@@ -123,7 +123,7 @@ def make_subject_str(playbook_num: int, role_num: int):
     return subject
 
 
-def detect(contexts: List[AnsibleRunContext], rules_dir: str = "", rules: list = [], rules_cache: list = []):
+def detect(contexts: List[AnsibleRunContext], rules_dir: str = "", rules: list = [], rules_cache: list = [], save_only_rule_result: bool = False):
     loaded_rules = []
     if rules_cache:
         loaded_rules = rules_cache
@@ -202,6 +202,9 @@ def detect(contexts: List[AnsibleRunContext], rules_dir: str = "", rules: list =
                     exc = traceback.format_exc()
                     r_result.error = f"failed to execute the rule `{rule.rule_id}`: {exc}"
                 n_result.rules.append(r_result)
+            # remove node details
+            if save_only_rule_result:
+                n_result.node = None
             t_result.nodes.append(n_result)
         ari_result.targets.append(t_result)
 

--- a/ansible_risk_insight/scanner.py
+++ b/ansible_risk_insight/scanner.py
@@ -209,6 +209,8 @@ class SingleScan(object):
     load_all_taskfiles: bool = False
     yaml_label_list: list = field(default_factory=list)
 
+    save_only_rule_result: bool = False
+
     extra_requirements: list = field(default_factory=list)
     resolve_failures: dict = field(default_factory=dict)
 
@@ -664,7 +666,9 @@ class SingleScan(object):
             target_name = self.collection_name
         if self.role_name:
             target_name = self.role_name
-        data_report, rules_cache = detect(self.contexts, rules_dir=self.rules_dir, rules=self.rules, rules_cache=self.rules_cache)
+        data_report, rules_cache = detect(
+            self.contexts, rules_dir=self.rules_dir, rules=self.rules, rules_cache=self.rules_cache, save_only_rule_result=self.save_only_rule_result
+        )
         self.rules_cache = rules_cache
         spec_mutations = data_report.get("spec_mutations", {})
         if spec_mutations:
@@ -833,6 +837,7 @@ class ARIScanner(object):
         raw_yaml: str = "",
         include_test_contents: bool = False,
         load_all_taskfiles: bool = False,
+        save_only_rule_result: bool = False,
         yaml_label_list: list = None,
         objects: bool = False,
         out_dir: str = "",
@@ -875,6 +880,7 @@ class ARIScanner(object):
             taskfile_only=taskfile_only,
             include_test_contents=include_test_contents,
             load_all_taskfiles=load_all_taskfiles,
+            save_only_rule_result=save_only_rule_result,
             yaml_label_list=yaml_label_list,
             out_dir=out_dir,
             root_dir=self.root_dir,


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

- add --save-only-rule-result option to reduce file size of `rule_result.json`