### PR TITLE
add --scan-per-target option which enables to output result files per target

### DIFF
--- a/ansible_risk_insight/finder.py
+++ b/ansible_risk_insight/finder.py
@@ -644,3 +644,90 @@ def label_yml_file(yml_path: str = "", yml_body: str = "", task_num_thresh: int 
     else:
         label = "others"
     return label, name_count, None
+
+
+def get_yml_label(file_path, root_path, task_num_threshold: int = -1):
+    relative_path = file_path.replace(root_path, "")
+    if relative_path[-1] == "/":
+        relative_path = relative_path[:-1]
+
+    label, _, error = label_yml_file(file_path, task_num_thresh=task_num_threshold)
+    role_name, role_path = get_role_info_from_path(file_path)
+    role_info = None
+    if role_name and role_path:
+        role_info = {"name": role_name, "path": role_path}
+
+    project_name, project_path = get_project_info_for_file(file_path, root_path)
+    project_info = None
+    if project_name and project_path:
+        project_info = {"name": project_name, "path": project_path}
+
+    # print(f"[{label}] {relative_path} {role_info}")
+    if error:
+        logger.debug(f"failed to get yml label:\n {error}")
+        label = "error"
+    return label, role_info, project_info
+
+
+def get_yml_list(root_dir: str, task_num_threshold: int = -1):
+    found_ymls = find_all_ymls(root_dir)
+    all_files = []
+    for yml_path in found_ymls:
+        label, role_info, project_info = get_yml_label(yml_path, root_dir, task_num_threshold)
+        if not role_info:
+            role_info = {}
+        if not project_info:
+            project_info = {}
+        if role_info:
+            if role_info["path"] and not role_info["path"].startswith(root_dir):
+                role_info["path"] = os.path.join(root_dir, role_info["path"])
+            role_info["is_external_dependency"] = True if "." in role_info["name"] else False
+        in_role = True if role_info else False
+        in_project = True if project_info else False
+        all_files.append(
+            {
+                "filepath": yml_path,
+                "path_from_root": yml_path.replace(root_dir, "").lstrip("/"),
+                "label": label,
+                "role_info": role_info,
+                "project_info": project_info,
+                "in_role": in_role,
+                "in_project": in_project,
+            }
+        )
+    return all_files
+
+
+def list_scan_target(root_dir: str, task_num_threshold: int = -1):
+    yml_list = get_yml_list(root_dir=root_dir, task_num_threshold=task_num_threshold)
+    known_roles = set()
+    all_targets = []
+    for yml_info in yml_list:
+        if yml_info["label"] not in ["playbook", "taskfile"]:
+            continue
+        role_path = ""
+        if yml_info["in_role"]:
+            role_path = yml_info["role_info"].get("path", None)
+        if role_path and role_path in known_roles:
+            continue
+        scan_type = ""
+        filepath = ""
+        path_from_root = ""
+        if role_path:
+            scan_type = "role"
+            filepath = role_path
+            path_from_root = role_path.replace(root_dir, "").lstrip("/")
+            known_roles.add(role_path)
+        else:
+            scan_type = yml_info["label"]
+            filepath = yml_info["filepath"]
+            path_from_root = yml_info["path_from_root"]
+        target_info = {
+            "filepath": filepath,
+            "path_from_root": path_from_root,
+            "scan_type": scan_type,
+        }
+        all_targets.append(target_info)
+    all_targets = sorted(all_targets, key=lambda x: x["filepath"])
+    all_targets = sorted(all_targets, key=lambda x: x["scan_type"])
+    return all_targets


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

- add --scan-per-target option which enables to output result files per target
  - target can be `playbook`, `role` and `taskfile` which is not in a role