### PR TITLE
PR to fix ari truncated output issue in case of module option value parameter

### DIFF
--- a/ansible_risk_insight/model_loader.py
+++ b/ansible_risk_insight/model_loader.py
@@ -81,9 +81,9 @@ from .finder import could_be_taskfile
 #   "brightcomputing.bcm-9.1.11+41615.gitfab9053.info"
 collection_info_dir_re = re.compile(r"^[a-z0-9_]+\.[a-z0-9_]+-[0-9]+\.[0-9]+\.[0-9]+.*\.info$")
 
-string_module_options_re = re.compile(r"^(?:[^ ]* ?)([a-z0-9_]+=(?:[^ ]*{{ [^ ]+ }}[^ ]*|[^ ])+\s?)")
+string_module_options_re = re.compile(r"^(?:[^ ]* ?)([a-z0-9_]+=(?:[^ ]*{{ [^*]+ }}[^ ]*|[^ ])+\s?)")
 
-string_module_option_parts_re = re.compile(r"([a-z0-9_]+=(?:[^ ]*{{ [^ ]+ }}[^ ]*|[^ ])+\s?)")
+string_module_option_parts_re = re.compile(r"([a-z0-9_]+=(?:[^ ]*{{ [^*]+ }}[^ ]*|[^ ])+\s?)")
 
 loop_task_option_names = [
     "loop",


### PR DESCRIPTION
PR to fix ari truncated output issue in case of module option value parameter. Fixes issue #223 

Input Play:
```
---
- name: Define timestamp
  set_fact: timestamp="{{ lookup('pipe', 'date +%Y%m%d_%H%M%S') }}"
  run_once: true
```

Output play w/o the fix:
```
- name: Define timestamp
  run_once: true
  ansible.builtin.set_fact:
	timestamp: "{{"
```

Output play with the fix:
```
- name: Define timestamp
  run_once: true
  ansible.builtin.set_fact:
	timestamp: "{{ lookup('pipe', 'date +%Y%m%d_%H%M%S') }}"
```