### PR TITLE
fix an issue of role/taskfile detction with specific path

### DIFF
--- a/ansible_risk_insight/parser.py
+++ b/ansible_risk_insight/parser.py
@@ -360,7 +360,7 @@ class Parser:
             try:
                 label = "others"
                 if ld.yaml_label_list:
-                    for (_fpath, _label, _) in ld.yaml_label_list:
+                    for _fpath, _label, _ in ld.yaml_label_list:
                         if _fpath == file_path:
                             label = _label
                 f = load_file(

--- a/ansible_risk_insight/ram_generator.py
+++ b/ansible_risk_insight/ram_generator.py
@@ -95,7 +95,7 @@ class RiskAssessmentModelGenerator(object):
         if self._parallel:
             joblib.Parallel(n_jobs=-1)(joblib.delayed(self.scan)(i, num, _type, _name) for (i, num, _type, _name) in input_list)
         else:
-            for (i, num, _type, _name) in input_list:
+            for i, num, _type, _name in input_list:
                 self.scan(i, num, _type, _name)
 
     def scan(self, i, num, type, name):

--- a/ansible_risk_insight/rules/sample_rule.py
+++ b/ansible_risk_insight/rules/sample_rule.py
@@ -33,7 +33,7 @@ class SampleRule(Rule):
     name: str = "EchoTaskContent"
     version: str = "v0.0.1"
     severity: Severity = Severity.NONE
-    tags: tuple = ("sample")
+    tags: tuple = "sample"
 
     def match(self, ctx: AnsibleRunContext) -> bool:
         # specify targets to be checked

--- a/ansible_risk_insight/tree.py
+++ b/ansible_risk_insight/tree.py
@@ -116,7 +116,7 @@ class TreeNode(object):
             return n, parent_keys
         parent_keys.add(node_key)
         new_parent_keys = parent_keys.copy()
-        for (src_key, dst_key) in src_dst_array:
+        for src_key, dst_key in src_dst_array:
             children_keys = []
             if node_key == src_key:
                 children_keys.append(dst_key)

--- a/ansible_risk_insight/yaml_utils.py
+++ b/ansible_risk_insight/yaml_utils.py
@@ -304,9 +304,7 @@ class FormattedYAML(YAML):
             data = self.load_all(stream=text)
         except ParserError as ex:
             data = None
-            logger.error(  # noqa: TRY400
-                "Invalid yaml, verify the file contents and try again. %s", ex
-            )
+            logger.error("Invalid yaml, verify the file contents and try again. %s", ex)  # noqa: TRY400
         except Exception as ex:
             print(ex)
         if preamble_comment is not None and isinstance(
@@ -431,7 +429,5 @@ class FormattedYAML(YAML):
                 # got an empty list item. drop any trailing spaces.
                 lines[i] = line.rstrip() + "\n"
 
-        text = "".join(
-            FormattedEmitter.drop_octothorpe_protection(line) for line in lines
-        )
+        text = "".join(FormattedEmitter.drop_octothorpe_protection(line) for line in lines)
         return text


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

- fix an issue of role/taskfile detection when some playbooks/taskfiles are in `roles/tasks`
- fix an issue where `yaml_label_list` was not correctly used for loading taskfiles