### PR TITLE
(fix) `datetime.datetime.utcnow()` deprecation warning

### DIFF
--- a/ansible_risk_insight/model_loader.py
+++ b/ansible_risk_insight/model_loader.py
@@ -2006,7 +2006,7 @@ def load_object(loadObj):
     elif target_type == LoadType.TASKFILE and loadObj.taskfile_only:
         loadObj.taskfiles = [obj.defined_in]
 
-    loadObj.timestamp = datetime.datetime.utcnow().isoformat()
+    loadObj.timestamp = datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')
 
 
 def find_playbook_role_module(path, use_ansible_doc=True):

--- a/ansible_risk_insight/ram_generator.py
+++ b/ansible_risk_insight/ram_generator.py
@@ -139,7 +139,7 @@ class RiskAssessmentModelGenerator(object):
         out_dir = os.path.join(self._scanner.root_dir, "log", type, name)
         path = os.path.join(out_dir, "ram_log.json")
 
-        scan_time = datetime.datetime.utcnow().isoformat()
+        scan_time = datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')
         new_record = {"type": type, "name": name, "succeed": not fail, "time": scan_time}
 
         logs = []

--- a/ansible_risk_insight/scanner.py
+++ b/ansible_risk_insight/scanner.py
@@ -1237,6 +1237,7 @@ class ARIScanner(object):
 
     def record_end(self, time_records: dict, record_name: str):
         end = datetime.datetime.now(datetime.timezone.utc)
+        end = end.replace(tzinfo=None)
         time_records[record_name]["end"] = end.strftime('%Y-%m-%dT%H:%M:%S.%f')
         begin = datetime.datetime.fromisoformat(time_records[record_name]["begin"])
         elapsed = (end - begin).total_seconds()

--- a/ansible_risk_insight/scanner.py
+++ b/ansible_risk_insight/scanner.py
@@ -700,7 +700,7 @@ class SingleScan(object):
             prm=self.prm,
             report=data_report,
             summary_txt=summary_txt,
-            scan_time=datetime.datetime.utcnow().isoformat(),
+            scan_time=datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f'),
         )
         self.result = data_report.get("ari_result", None)
         return
@@ -1233,11 +1233,11 @@ class ARIScanner(object):
 
     def record_begin(self, time_records: dict, record_name: str):
         time_records[record_name] = {}
-        time_records[record_name]["begin"] = datetime.datetime.utcnow().isoformat()
+        time_records[record_name]["begin"] = datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')
 
     def record_end(self, time_records: dict, record_name: str):
-        end = datetime.datetime.utcnow()
-        time_records[record_name]["end"] = end.isoformat()
+        end = datetime.datetime.now(datetime.timezone.utc)
+        time_records[record_name]["end"] = end.strftime('%Y-%m-%dT%H:%M:%S.%f')
         begin = datetime.datetime.fromisoformat(time_records[record_name]["begin"])
         elapsed = (end - begin).total_seconds()
         time_records[record_name]["elapsed"] = elapsed


### PR DESCRIPTION
Getting below warning messages while running test cases in app
>  /.../python3.12/site-packages/ansible_risk_insight/scanner.py:1236: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    time_records[record_name]["begin"] = datetime.datetime.utcnow().isoformat()

>  /.../python3.12/site-packages/ansible_risk_insight/scanner.py:1239: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    end = datetime.datetime.utcnow()

>  /.../python3.12/site-packages/ansible_risk_insight/model_loader.py:2009: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    loadObj.timestamp = datetime.datetime.utcnow().isoformat()

>  /.../python3.12/site-packages/ansible_risk_insight/scanner.py:703: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    scan_time=datetime.datetime.utcnow().isoformat(),